### PR TITLE
revert accepting only mobile data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ var integration = require('segmentio-integration');
  */
 
 var AppsFlyer = module.exports = integration('AppsFlyer')
-  .channels(['mobile'])
+  .channels(['mobile', 'client', 'server'])
   .ensure('settings.appsFlyerDevKey')
   .endpoint('https://api2.appsflyer.com/inappevent/')
   .retries(2);

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ describe('AppsFlyer', function() {
   it('should have the correct settings', function() {
     test
       .name('AppsFlyer')
-      .channels(['mobile'])
+      .channels(['mobile', 'client', 'server'])
       .endpoint('https://api2.appsflyer.com/inappevent/')
       .ensure('settings.appsFlyerDevKey');
   });


### PR DESCRIPTION
because this integration is really supposed to be augmentative on top of af's bundled sdk so we should still accept non mobile data assuming customers will send appsflyer_id
