### PR TITLE
Make tests actually check requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "merge-util": "^0.1.0",
     "mocha": "*",
     "segmentio-facade": "2.x",
-    "segmentio-integration-tester": "1.x",
+    "segmentio-integration-tester": "^2.0.2",
     "should": "~4.0.4",
     "uid": "0.0.2"
   },

--- a/test/fixtures/track-event-android.json
+++ b/test/fixtures/track-event-android.json
@@ -38,7 +38,7 @@
   },
   "output": {
     "appsflyer_id": "gucci-mane",
-    "advertisingId": "159358",
+    "advertising_id": "159358",
     "eventName": "season 2 of stranger things now",
     "eventValue": "",
     "eventCurrency": "USD",
@@ -47,4 +47,3 @@
     "af_events_api": "true"
   }
 }
-

--- a/test/fixtures/track-event-ios.json
+++ b/test/fixtures/track-event-ios.json
@@ -44,7 +44,7 @@
     "eventValue": "",
     "eventCurrency": "USD",
     "ip": "10.0.0.2",
-    "eventTime": "2014-05-15 12:17:00.000",
+    "eventTime": "2016-08-03 00:00:00.000",
     "af_events_api": "true"
   }
 }

--- a/test/fixtures/track-event-props-android.json
+++ b/test/fixtures/track-event-props-android.json
@@ -40,15 +40,12 @@
   },
   "output": {
     "appsflyer_id": "gucci-mane",
-    "advertising_id": "15938",
+    "advertising_id": "159358",
     "eventName": "why did no one care about barbra",
-    "eventValue": {
-      "af_revenue": "17.38"
-    },
+    "eventValue": "{\"af_revenue\":\"17.38\"}",
     "eventCurrency": "USD",
     "ip": "10.0.0.2",
     "eventTime": "2016-08-03 00:00:00.000",
     "af_events_api": "true"
   }
 }
-

--- a/test/fixtures/track-event-props-ios.json
+++ b/test/fixtures/track-event-props-ios.json
@@ -43,9 +43,7 @@
     "idfa": "159358",
     "bundle_id": "com.segment.TestApp",
     "eventName": "rich AF",
-    "eventValue": {
-      "af_revenue": "17.38"
-    },
+    "eventValue": "{\"af_revenue\":\"17.38\"}",
     "eventCurrency": "USD",
     "ip": "10.0.0.2",
     "eventTime": "2016-08-03 00:00:00.000",

--- a/test/index.js
+++ b/test/index.js
@@ -114,7 +114,7 @@ describe('AppsFlyer', function() {
 
       test
         .track(json.input)
-        .request(1)
+        .request(0)
         .sends(json.output)
         .expects(200)
         .end(done);
@@ -125,7 +125,7 @@ describe('AppsFlyer', function() {
 
       test
         .track(json.input)
-        .request(1)
+        .request(0)
         .sends(json.output)
         .expects(200)
         .end(done);
@@ -136,7 +136,7 @@ describe('AppsFlyer', function() {
 
       test
         .track(json.input)
-        .request(1)
+        .request(0)
         .sends(json.output)
         .expects(200)
         .end(done);
@@ -147,7 +147,7 @@ describe('AppsFlyer', function() {
 
       test
         .track(json.input)
-        .request(1)
+        .request(0)
         .sends(json.output)
         .expects(200)
         .end(done);


### PR DESCRIPTION
Update to a version of the integration-tester that throws an error for assertions that aren't run, make the tests put the assertions on the right request.
