### PR TITLE
Set endpoint based on device type rather than library

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
 
-1.1.3 / 2017-03-30
+1.2.0 / 2017-03-30
 ==================
 
   * Add better support for checking device type and handling requests from server-side libraries

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+1.1.3 / 2017-03-30
+==================
+
+  * Add better support for checking device type and handling requests from server-side libraries
+
 1.1.2 / 2017-03-07
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,11 +22,20 @@ var AppsFlyer = module.exports = integration('AppsFlyer')
  */
 
 AppsFlyer.ensure(function(msg, settings) {
-  if (contains(msg.library(), 'ios') && !settings.appleAppID) {
+
+  if (!msg.device().type) {
+    return this.invalid('Events to AppsFlyer must specify a device type as a contextual property');
+  }
+
+  if (!msg.device().advertisingId) {
+    return this.invalid('Events to AppsFlyer must specify an advertisingId as a contextual property');
+  }
+
+  if (msg.device().type ==='ios' && !settings.appleAppID) {
     return this.invalid('iOS projects must configure the Apple App ID in the settings');
   }
 
-  if (contains(msg.library(), 'android') && !settings.androidAppID) {
+  if (msg.device().type ==='android' && !settings.androidAppID) {
     return this.invalid('Android projects must configure the Android App ID in the settings to send server to server events');
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,29 +22,19 @@ var AppsFlyer = module.exports = integration('AppsFlyer')
  */
 
 AppsFlyer.ensure(function(msg, settings) {
-  // Check to ensure msg has a device contextual property
-  var deviceInfo = msg.device();
-  if (!deviceInfo) {
-    return this.reject('Events to AppsFlyer must specify device type and advertisingId as contextual properties');
-  }
-  
   // Check to ensure message has advertisingId as a property of device object
+  var deviceInfo = msg.device() || {};
   if (!deviceInfo.advertisingId) {
-    return this.invalid('Events to AppsFlyer must specify an advertisingId as a contextual property');
+    return this.invalid('Events to AppsFlyer must specify an advertisingId as a contextual property of the device object');
   }
 
-  // Check to ensure message has a device type (ios or android) as a property of device object
-  if (!deviceInfo.type) {
-    return this.reject('Events to AppsFlyer must specify a device type as a contextual property');
-  }
-  
   // Check to ensure device type is either ios or android (case insensitive)
-  var deviceType = deviceInfo.type.toLowerCase();
+  var deviceType = getDeviceType(msg);
   if (deviceType !== 'ios' && deviceType !== 'android') {
     return this.reject('AppsFlyer integration is currently only supported for ios or android devices');
   }
 
-  // Check to ensure settings containt an Apple App ID if device type is ios
+  // Check to ensure settings contain an Apple App ID if device type is ios
   if (deviceType ==='ios' && !settings.appleAppID) {
     return this.invalid('iOS projects must configure the Apple App ID in the settings');
   }
@@ -76,7 +66,7 @@ AppsFlyer.prototype.track = function(track, fn) {
    */
 
   // Since our ensure block ensures this to be available
-  var deviceType = track.device().type.toLowerCase();
+  var deviceType = getDeviceType(track);
   var endpoint = selectEndpoint(deviceType, this.settings);
   var options = track.options('AppsFlyer');
   var device = track.device() || {};
@@ -87,10 +77,12 @@ AppsFlyer.prototype.track = function(track, fn) {
     appsflyer_id: options.appsFlyerId,
     eventName: track.event(),
     eventCurrency: track.currency(), // defaults to 'USD'
-    ip: track.ip(),
     eventTime: timestamp,
     af_events_api: 'true'
   };
+  
+  // Add ip address if event is client side
+  if (track.ip()) payload.ip = track.ip();
 
   // AF requires you to change this to empty string if empty
   // Also, everything in the payload should be stringified
@@ -112,7 +104,7 @@ AppsFlyer.prototype.track = function(track, fn) {
     .type('json')
     .set('authentication', this.settings.appsFlyerDevKey)
     .send(payload)
-    .end(this.handle(fn));
+    .end(fn);
 };
 
 /**
@@ -176,4 +168,29 @@ function stringify(obj) {
   }
   // Events will be silently dropped if you do not stringify
   return JSON.stringify(ret);
+}
+
+/**
+ * Get the correct device type from the track payload.
+ * This function is required to support backwards compatibility
+ * with the functionality of this integration prior to v. 1.1.3
+ * 
+ * @api private
+ * @param {Track} track
+ * @return {String} deviceType
+ */
+
+function getDeviceType(track) {
+  var deviceType;
+  var deviceInfo = track.device() || {};
+
+  if (deviceInfo.type) {
+    deviceType = deviceInfo.type.toLowerCase();
+  } else if (contains(track.library(), 'ios')) {
+    deviceType = 'ios';
+  } else {
+    deviceType = 'android';
+  }
+
+  return deviceType;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,6 +116,20 @@ AppsFlyer.prototype.track = function(track, fn) {
 };
 
 /**
+ * Check which library the message is from
+ *
+ * @api private
+ * @param {Object} library
+ * @param {String} str
+ * return true/false
+ */
+
+function contains(library, str) {
+  var name = typeof library === 'string' ? library : library.name;
+  return name.toLowerCase().indexOf(str) !== -1;
+}
+
+/**
  * Get the correct endpoint based on device type.
  * 
  * @api private

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,20 +22,35 @@ var AppsFlyer = module.exports = integration('AppsFlyer')
  */
 
 AppsFlyer.ensure(function(msg, settings) {
-
-  if (!msg.device().type) {
-    return this.invalid('Events to AppsFlyer must specify a device type as a contextual property');
+  // Check to ensure msg has a device contextual property
+  var deviceInfo = msg.device();
+  if (!deviceInfo) {
+    return this.reject('Events to AppsFlyer must specify device type and advertisingId as contextual properties');
   }
-
-  if (!msg.device().advertisingId) {
+  
+  // Check to ensure message has advertisingId as a property of device object
+  if (!deviceInfo.advertisingId) {
     return this.invalid('Events to AppsFlyer must specify an advertisingId as a contextual property');
   }
 
-  if (msg.device().type ==='ios' && !settings.appleAppID) {
+  // Check to ensure message has a device type (ios or android) as a property of device object
+  if (!deviceInfo.type) {
+    return this.reject('Events to AppsFlyer must specify a device type as a contextual property');
+  }
+  
+  // Check to ensure device type is either ios or android (case insensitive)
+  var deviceType = deviceInfo.type.toLowerCase();
+  if (deviceType !== 'ios' && deviceType !== 'android') {
+    return this.reject('AppsFlyer integration is currently only supported for ios or android devices');
+  }
+
+  // Check to ensure settings containt an Apple App ID if device type is ios
+  if (deviceType ==='ios' && !settings.appleAppID) {
     return this.invalid('iOS projects must configure the Apple App ID in the settings');
   }
 
-  if (msg.device().type ==='android' && !settings.androidAppID) {
+  // Check to ensure settings containt an Android App ID if device type is android
+  if (deviceType ==='android' && !settings.androidAppID) {
     return this.invalid('Android projects must configure the Android App ID in the settings to send server to server events');
   }
 
@@ -61,7 +76,8 @@ AppsFlyer.prototype.track = function(track, fn) {
    */
 
   // Since our ensure block ensures this to be available
-  var endpoint = selectEndpoint(track.library(), this.settings);
+  var deviceType = track.device().type.toLowerCase();
+  var endpoint = selectEndpoint(deviceType, this.settings);
   var options = track.options('AppsFlyer');
   var device = track.device() || {};
   // needs to be in UTC timezone i.e. "2016-08-03 12:17:00.000
@@ -81,7 +97,7 @@ AppsFlyer.prototype.track = function(track, fn) {
   var props = reject(track.properties({ revenue: 'af_revenue' }));
   payload.eventValue = isEmpty(props) ? '' : stringify(props);
 
-  var ios = contains(track.library(), 'ios');
+  var ios = deviceType === 'ios';
   if (ios) {
     if (device.advertisingId) {
       payload.idfa = device.advertisingId.toString();
@@ -100,36 +116,22 @@ AppsFlyer.prototype.track = function(track, fn) {
 };
 
 /**
- * Check which library the message is from
- *
- * @api private
- * @param {Object} library
- * @param {String} str
- * return true/false
- */
-
-function contains(library, str) {
-  var name = typeof library === 'string' ? library : library.name;
-  return name.toLowerCase().indexOf(str) !== -1;
-}
-
-/**
- * Get the correct endpoint based on library
- *
+ * Get the correct endpoint based on device type.
+ * 
  * @api private
  * @param {Object} library
  * @return {String} endpoint
  */
 
-function selectEndpoint(library, settings) {
+function selectEndpoint(deviceType, settings) {
   var endpoint;
-  if (contains(library, 'ios')) {
+  if (deviceType === 'ios') {
     // appsflyer wants ios to always have 'id' prefixed
     // metadata validates that they do not add the id in the settings so we can do it here
     endpoint = 'id' + settings.appleAppID;
   } else {
     endpoint = settings.androidAppID;
-  }
+  } 
   return endpoint;
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ var reject = require('reject');
  */
 
 var AppsFlyer = module.exports = integration('AppsFlyer')
-  .channels(['mobile', 'client', 'server'])
+  .channels(['server'])
   .ensure('settings.appsFlyerDevKey')
   .endpoint('https://api2.appsflyer.com/inappevent/')
   .retries(2);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-appsflyer",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Appsflyer server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-appsflyer",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Appsflyer server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {

--- a/test/fixtures/track-event-android.json
+++ b/test/fixtures/track-event-android.json
@@ -17,7 +17,7 @@
       },
       "device": {
         "manufacturer": "some-brand",
-        "type": "ios",
+        "type": "android",
         "advertisingId": "159358"
       },
       "network": { "carrier": "some-carrier" },

--- a/test/fixtures/track-event-props-android.json
+++ b/test/fixtures/track-event-props-android.json
@@ -16,7 +16,7 @@
       },
       "device": {
         "manufacturer": "some-brand",
-        "type": "ios",
+        "type": "android",
         "advertisingId": "159358"
       },
       "network": { "carrier": "some-carrier" },

--- a/test/fixtures/track-event-server-side.json
+++ b/test/fixtures/track-event-server-side.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "context": {
+      "library": {
+        "name": "analytics-node",
+        "version": "2.0.2"
+      },
+      "device": {
+        "advertisingId": "159358"
+      }
+    },
+    "event": "Order Completed",
+    "properties": {},
+    "timestamp": "2016-08-03",
+    "type": "track",
+    "userId": "bill_brasky",
+    "writeKey": "YGgRfrtPZvc2EzW9yZ7eRVkdXGUIB6T6",
+    "sentAt": "2016-12-13T22:27:57.792Z",
+    "integrations": {
+      "AppsFlyer": {
+          "appsFlyerId": "gucci-mane"
+      }
+    },
+    "receivedAt": "2016-12-13T22:27:59.604Z",
+    "originalTimestamp": "2016-12-13T22:27:57.775Z"
+  },
+  "output": {
+    "appsflyer_id": "gucci-mane",
+    "advertising_id": "159358",
+    "eventName": "Order Completed",
+    "eventValue": "",
+    "eventCurrency": "USD",
+    "eventTime": "2016-08-03 00:00:00.000",
+    "af_events_api": "true"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ describe('AppsFlyer', function() {
   it('should have the correct settings', function() {
     test
       .name('AppsFlyer')
-      .channels(['mobile', 'client', 'server'])
+      .channels(['server'])
       .endpoint('https://api2.appsflyer.com/inappevent/')
       .ensure('settings.appsFlyerDevKey');
   });

--- a/test/index.js
+++ b/test/index.js
@@ -34,7 +34,11 @@ describe('AppsFlyer', function() {
 
       msg = {
         context: {
-          library: { name: 'analytics-ios' }
+          device: {
+            manufacturer: 'some-brand',
+            type: 'ios',
+            advertisingId: '159358'
+          }
         },
         integrations: {
           AppsFlyer: {
@@ -51,7 +55,11 @@ describe('AppsFlyer', function() {
 
       msg = {
         context: {
-          library: { name: 'analytics-android' }
+          device: {
+            manufacturer: 'some-brand',
+            type: 'android',
+            advertisingId: '159358'
+          }
         },
         integrations: {
           AppsFlyer: {
@@ -66,10 +74,38 @@ describe('AppsFlyer', function() {
     it('should be invalid if you do not manually send appsflyer_id', function() {
       msg = {
         context: {
-          library: { name: 'analytics-ios' }
+          device: {
+            manufacturer: 'some-brand',
+            type: 'ios',
+            advertisingId: '159358'
+          }
         }
       };
 
+      test.invalid(msg, settings);
+    });
+
+    it('should be invalid if you do not send an advertisingId', function() {
+      msg = {
+        context: {
+          device: {
+            manufacturer: 'some-brand',
+            advertisingId: '159358'
+          }
+        }
+      };
+      test.invalid(msg, settings);
+    });
+
+    it('should be invalid if you do not send a device type', function() {
+      msg = {
+        context: {
+          device: {
+            manufacturer: 'some-brand',
+            type: 'ios'
+          }
+        }
+      };
       test.invalid(msg, settings);
     });
 
@@ -78,7 +114,11 @@ describe('AppsFlyer', function() {
 
       msg = {
         context: {
-          library: { name: 'analytics-android' }
+          device: {
+            manufacturer: 'some-brand',
+            type: 'android',
+            advertisingId: '159358'
+          }
         },
         integrations: {
           AppsFlyer: {
@@ -95,7 +135,11 @@ describe('AppsFlyer', function() {
 
       msg = {
         context: {
-          library: { name: 'analytics-ios' }
+          device: {
+            manufacturer: 'some-brand',
+            type: 'ios',
+            advertisingId: '159358'
+          }
         },
         integrations: {
           AppsFlyer: {

--- a/test/index.js
+++ b/test/index.js
@@ -97,30 +97,6 @@ describe('AppsFlyer', function() {
       test.invalid(msg, settings);
     });
 
-    it('should be invalid if you do not send a device type', function() {
-      msg = {
-        context: {
-          device: {
-            manufacturer: 'some-brand',
-            type: 'ios'
-          }
-        }
-      };
-      test.invalid(msg, settings);
-    });
-
-    it('should be invalid if you do not send "ios" or "android" as device type values', function() {
-      msg = {
-        context: {
-          device: {
-            manufacturer: 'some-brand',
-            type: 'some_random_value'
-          }
-        }
-      };
-      test.invalid(msg, settings);
-    });
-
     it('should be valid without apple app id if android', function() {
       delete settings.appleAppID;
 
@@ -165,6 +141,17 @@ describe('AppsFlyer', function() {
   });
 
   describe('track', function() {
+    it('should default the device type to android if the event is from a server-side library or device.type is not explicitly defined', function(done) {
+      var json = test.fixture('track-event-server-side');
+
+      test
+        .track(json.input)
+        .request(0)
+        .sends(json.output)
+        .expects(200)
+        .end(done);
+    });
+
     it('should send a track event for ios', function(done) {
       var json = test.fixture('track-event-ios');
 

--- a/test/index.js
+++ b/test/index.js
@@ -109,6 +109,18 @@ describe('AppsFlyer', function() {
       test.invalid(msg, settings);
     });
 
+    it('should be invalid if you do not send "ios" or "android" as device type values', function() {
+      msg = {
+        context: {
+          device: {
+            manufacturer: 'some-brand',
+            type: 'some_random_value'
+          }
+        }
+      };
+      test.invalid(msg, settings);
+    });
+
     it('should be valid without apple app id if android', function() {
       delete settings.appleAppID;
 


### PR DESCRIPTION
This PR addresses this Jira issue: https://segment.atlassian.net/browse/EPD-1428

Appsflyer has distinct api endpoints for ios and android events. Previously, we were picking that endpoint based on the library that the event came from. This updates that logic in the integration to instead choose the endpoint based on the event's `device.type` property. It also adds some tests to ensure that this property exists and that the value is standardized as either 'ios' or 'android' (case insensitive) as it is with our mobile sdks.

This should allow for server side events to properly reach the correct endpoint.